### PR TITLE
Add support for HTTP Basic Auth to Jenkins collector

### DIFF
--- a/BuildCollector/README.md
+++ b/BuildCollector/README.md
@@ -38,3 +38,7 @@ for information about sourcing this properties file.
 
     #Determines if build console log is collected - defaults to false
     jenkins.saveLog=true
+
+    #Jenkins auth - set username/apiKey to use HTTP Basic Auth (blank=no auth)
+    jenkins.username=
+    jenkins.apiKey=

--- a/BuildCollector/src/main/java/com/capitalone/dashboard/collector/DefaultHudsonClient.java
+++ b/BuildCollector/src/main/java/com/capitalone/dashboard/collector/DefaultHudsonClient.java
@@ -258,7 +258,8 @@ public class DefaultHudsonClient implements HudsonClient {
 
     private ResponseEntity<String> makeRestCall(URI uri) {
         // Basic Auth only.
-        if (this.settings.isAuthRequired()) {
+        if (StringUtils.isNotEmpty(this.settings.getUsername())
+                && StringUtils.isNotEmpty(this.settings.getApiKey())) {
             return rest.exchange(uri, HttpMethod.GET,
                     new HttpEntity<>(createHeaders(this.settings.getUsername(), this.settings.getApiKey())),
                     String.class);

--- a/BuildCollector/src/main/java/com/capitalone/dashboard/collector/DefaultHudsonClient.java
+++ b/BuildCollector/src/main/java/com/capitalone/dashboard/collector/DefaultHudsonClient.java
@@ -76,9 +76,7 @@ public class DefaultHudsonClient implements HudsonClient {
         Map<HudsonJob, Set<Build>> result = new LinkedHashMap<>();
         try {
             String url = StringUtils.removeEnd(instanceUrl, "/") + JOBS_URL_SUFFIX;
-            ResponseEntity<String> responseEntity = makeRestCall(URI.create(url),
-                    this.settings.isAuthRequired(),
-                    this.settings.getUsername(), this.settings.getApiKey());
+            ResponseEntity<String> responseEntity = makeRestCall(URI.create(url));
             String returnJSON = responseEntity.getBody();
             JSONParser parser = new JSONParser();
 
@@ -123,9 +121,7 @@ public class DefaultHudsonClient implements HudsonClient {
     public Build getBuildDetails(String buildUrl) {
         try {
             String url = StringUtils.removeEnd(buildUrl, "/") + BUILD_DETAILS_URL_SUFFIX;
-            ResponseEntity<String> result = makeRestCall(URI.create(url),
-                    this.settings.isAuthRequired(),
-                    this.settings.getUsername(), this.settings.getApiKey());
+            ResponseEntity<String> result = makeRestCall(URI.create(url));
             String returnJSON = result.getBody();
             JSONParser parser = new JSONParser();
 
@@ -260,12 +256,11 @@ public class DefaultHudsonClient implements HudsonClient {
         }
     }
 
-    private ResponseEntity<String> makeRestCall(
-            URI uri, boolean authRequired, String userId, String password) {
+    private ResponseEntity<String> makeRestCall(URI uri) {
         // Basic Auth only.
-        if (authRequired) {
+        if (this.settings.isAuthRequired()) {
             return rest.exchange(uri, HttpMethod.GET,
-                    new HttpEntity<>(createHeaders(userId, password)),
+                    new HttpEntity<>(createHeaders(this.settings.getUsername(), this.settings.getApiKey())),
                     String.class);
 
         } else {
@@ -288,9 +283,7 @@ public class DefaultHudsonClient implements HudsonClient {
 
     private String getLog(String buildUrl) {
         ResponseEntity<String> responseEntity = makeRestCall(
-                URI.create(buildUrl + "consoleText"),
-                this.settings.isAuthRequired(),
-                this.settings.getUsername(), this.settings.getApiKey());
+                URI.create(buildUrl + "consoleText"));
         String returnJSON = responseEntity.getBody();
 
         return returnJSON;

--- a/BuildCollector/src/main/java/com/capitalone/dashboard/collector/DefaultHudsonClient.java
+++ b/BuildCollector/src/main/java/com/capitalone/dashboard/collector/DefaultHudsonClient.java
@@ -23,7 +23,7 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestOperations;
 
 import java.net.URI;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
@@ -279,10 +279,9 @@ public class DefaultHudsonClient implements HudsonClient {
         return new HttpHeaders() {
             {
                 String auth = userId + ":" + password;
-                byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(Charset
-                        .forName("US-ASCII")));
+                byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.US_ASCII));
                 String authHeader = "Basic " + new String(encodedAuth);
-                set("Authorization", authHeader);
+                set(HttpHeaders.AUTHORIZATION, authHeader);
             }
         };
     }

--- a/BuildCollector/src/main/java/com/capitalone/dashboard/collector/HudsonSettings.java
+++ b/BuildCollector/src/main/java/com/capitalone/dashboard/collector/HudsonSettings.java
@@ -16,7 +16,6 @@ public class HudsonSettings {
     private String cron;
     private boolean saveLog = false;
     private List<String> servers;
-    private boolean authRequired = false;
     private String username;
     private String apiKey;
 
@@ -42,14 +41,6 @@ public class HudsonSettings {
 
     public void setServers(List<String> servers) {
         this.servers = servers;
-    }
-
-    public boolean isAuthRequired() {
-        return authRequired;
-    }
-
-    public void setAuthRequired(boolean authRequired) {
-        this.authRequired = authRequired;
     }
 
     public String getUsername() {

--- a/BuildCollector/src/main/java/com/capitalone/dashboard/collector/HudsonSettings.java
+++ b/BuildCollector/src/main/java/com/capitalone/dashboard/collector/HudsonSettings.java
@@ -11,11 +11,14 @@ import java.util.List;
 @Component
 @ConfigurationProperties(prefix = "jenkins")
 public class HudsonSettings {
-    
+
 
     private String cron;
     private boolean saveLog = false;
     private List<String> servers;
+    private boolean authRequired = false;
+    private String username;
+    private String apiKey;
 
     public String getCron() {
         return cron;
@@ -40,4 +43,29 @@ public class HudsonSettings {
     public void setServers(List<String> servers) {
         this.servers = servers;
     }
+
+    public boolean isAuthRequired() {
+        return authRequired;
+    }
+
+    public void setAuthRequired(boolean authRequired) {
+        this.authRequired = authRequired;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
 }

--- a/BuildCollector/src/test/java/com/capitalone/dashboard/collector/DefaultHudsonClientTests.java
+++ b/BuildCollector/src/test/java/com/capitalone/dashboard/collector/DefaultHudsonClientTests.java
@@ -12,6 +12,10 @@ import org.junit.runner.RunWith;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestOperations;
 
 import java.io.IOException;
@@ -42,7 +46,8 @@ public class DefaultHudsonClientTests {
 
     @Test
     public void instanceJobs_emptyResponse_returnsEmptyMap() {
-        when(rest.getForObject(Matchers.any(URI.class), eq(String.class))).thenReturn("");
+        when(rest.exchange(Matchers.any(URI.class), eq(HttpMethod.GET), Matchers.any(HttpEntity.class), eq(String.class)))
+                .thenReturn(new ResponseEntity<String>("", HttpStatus.OK));
 
         Map<HudsonJob, Set<Build>> jobs = hudsonClient.getInstanceJobs(URL);
 
@@ -51,7 +56,8 @@ public class DefaultHudsonClientTests {
 
     @Test
     public void instanceJobs_twoJobsTwoBuilds() throws Exception {
-        when(rest.getForObject(Matchers.any(URI.class), eq(String.class))).thenReturn(getJson("instanceJobs_twoJobsTwoBuilds.json"));
+        when(rest.exchange(Matchers.any(URI.class), eq(HttpMethod.GET), Matchers.any(HttpEntity.class), eq(String.class)))
+                .thenReturn(new ResponseEntity<String>(getJson("instanceJobs_twoJobsTwoBuilds.json"), HttpStatus.OK));
 
         Map<HudsonJob, Set<Build>> jobs = hudsonClient.getInstanceJobs(URL);
 
@@ -81,7 +87,8 @@ public class DefaultHudsonClientTests {
 
     @Test
     public void buildDetails_full() throws Exception {
-        when(rest.getForObject(Matchers.any(URI.class), eq(String.class))).thenReturn(getJson("buildDetails_full.json"));
+        when(rest.exchange(Matchers.any(URI.class), eq(HttpMethod.GET), Matchers.any(HttpEntity.class), eq(String.class)))
+                .thenReturn(new ResponseEntity<String>(getJson("buildDetails_full.json"), HttpStatus.OK));
 
         Build build = hudsonClient.getBuildDetails(URL);
 

--- a/sample.properties
+++ b/sample.properties
@@ -27,7 +27,6 @@ jenkins.servers[0]=http://hudson.company.com
     #Determines if build console log is collected - defaults to false
 jenkins.saveLog=true
 
-    #Jenkins auth - set authRequired=true to use HTTP Basic Auth (false=no auth)
-jenkins.authRequired=false
+    #Jenkins auth - set username/apiKey to use HTTP Basic Auth (blank=no auth)
 jenkins.username=
 jenkins.apiKey=

--- a/sample.properties
+++ b/sample.properties
@@ -26,3 +26,8 @@ jenkins.servers[0]=http://hudson.company.com
 
     #Determines if build console log is collected - defaults to false
 jenkins.saveLog=true
+
+    #Jenkins auth - set authRequired=true to use HTTP Basic Auth (false=no auth)
+jenkins.authRequired=false
+jenkins.username=
+jenkins.apiKey=

--- a/sample.properties
+++ b/sample.properties
@@ -14,15 +14,15 @@ spring.data.mongodb.username=db
 spring.data.mongodb.password=dbpass
 
     #Collector schedule (required)
-Jenkins.cron=0 0/5 * * * *
 github.cron=0 0/5 * * * *
+jenkins.cron=0 0/5 * * * *
 sonar.cron=0 0/5 * * * *
 udeploy.cron=0 0/5 * * * *
 subversion.cron=0 0/5 * * * *
 feature.cron=0 0/5 * * * *
 
     #Hudson server (required) - Can provide multiple
-Jenkins.servers[0]=http://hudson.company.com
+jenkins.servers[0]=http://hudson.company.com
 
     #Determines if build console log is collected - defaults to false
-Jenkins.saveLog=true
+jenkins.saveLog=true


### PR DESCRIPTION
Allows the Jenkins collector to connect to Jenkins servers that require authentication.

To enable basic auth, set the following properties:

``` ini
jenkins.authRequired=true
jenkins.username=jenkins-username-goes-here
jenkins.apiKey=jenkins-apiKey-goes-here
```
